### PR TITLE
Automatically get latest version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,25 @@
 FROM debian:stretch
 MAINTAINER IronicBadger <alexktz@gmail.com>
 
-ENV SNAPRAID_VERSION="11.3"
-
 # Builds SnapRAID from source
-RUN apt-get update && \
-  apt-get upgrade -y && \
-  apt-get install -y \
-    gcc \
-    git \
-    make \
+RUN apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y \
     checkinstall \
     curl \
-    libblkid1
-RUN curl -LO https://github.com/amadvance/snapraid/releases/download/v$SNAPRAID_VERSION/snapraid-$SNAPRAID_VERSION.tar.gz && \
-  tar -xvf snapraid-$SNAPRAID_VERSION.tar.gz && \
-  cd snapraid-$SNAPRAID_VERSION && \
-  ./configure && \
-  make -j8 && \
-  make -j8 check && \
-  checkinstall -Dy --install=no --nodoc && \
-  mkdir /build && \
-  cp *.deb /build/snapraid-from-source.deb
+    gcc \
+    git \
+    libblkid1 \
+    make
+
+RUN \
+  SNAPRAID_VERSION=$(curl --silent https://www.snapraid.it/download | grep -Po "\d+\.\d+" | tail -1) \
+  && curl -LO https://github.com/amadvance/snapraid/releases/download/v$SNAPRAID_VERSION/snapraid-$SNAPRAID_VERSION.tar.gz \
+  && tar -xvf snapraid-$SNAPRAID_VERSION.tar.gz \
+  && cd snapraid-$SNAPRAID_VERSION \
+  && ./configure \
+  && make -j8 \
+  && make -j8 check \
+  && checkinstall -Dy --install=no --nodoc \
+  && mkdir /build \
+  && cp *.deb /build/snapraid-from-source.deb

--- a/README.md
+++ b/README.md
@@ -11,6 +11,4 @@ sudo dpkg -i snapraid*.deb
 
 The build script spins up a container, executes the `Dockerfile` which performs the actual build from source. The script then copies the built `.deb` artifact out onto your local system ready for installation using `dpkg`.
 
-If the version is out of date, please submit a Pull Request or open an issue.
-
-<Feb 2019> - This is still actively maintained but I don't seem to get notifications. I'm active on the linuxserver.io discord or my email address is in the dockerfile. Give that a go if your PR sits stale for a while!
+<Feb 2019> - This is still actively maintained but I don't seem to get notifications. I'm active on the [linuxserver.io discord](https://discord.gg/YWrKVTn) or my email address is in the dockerfile. Give that a go if your PR sits stale for a while!


### PR DESCRIPTION
I've moved the ENV var to a curl+grep command that finds the version number from the official snapraid website, instead of relying on manually modifying it.

I also moved the '&&' in the Dockerfile to make it easier to spot if you've missed something when adding new commands.

I also alphabetized the packages installed