### PR TITLE
Add configureable version number

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:buster
 MAINTAINER Alex Kretzschmar <alexktz@gmail.com>
 
-ENV SNAPRAID_VERSION="11.5"
+ARG SNAPRAID_VERSION="11.5"
 
 # Builds SnapRAID from source
 RUN echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list && \
@@ -13,9 +13,9 @@ RUN echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sou
         checkinstall \
         curl \
         libblkid1
-RUN curl -LO https://github.com/amadvance/snapraid/releases/download/v$SNAPRAID_VERSION/snapraid-$SNAPRAID_VERSION.tar.gz && \
-      tar -xvf snapraid-$SNAPRAID_VERSION.tar.gz && \
-      cd snapraid-$SNAPRAID_VERSION && \
+RUN curl -LO https://github.com/amadvance/snapraid/releases/download/v${SNAPRAID_VERSION}/snapraid-${SNAPRAID_VERSION}.tar.gz && \
+      tar -xvf snapraid-${SNAPRAID_VERSION}.tar.gz && \
+      cd snapraid-${SNAPRAID_VERSION} && \
       ./configure && \
       make -j4 && \
       make -j4 check && \

--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@ This container will allow you to build a Snapraid `.deb` file without installing
 
 ### Usage
 
-```
-./build.sh
+```sh
+./build.sh [<version>] # e.g. ./build.sh 11.5
 sudo dpkg -i snapraid*.deb
 ```
+
+If the version is omitted, the default version is used.
 
 The build script spins up a container, executes the `Dockerfile` which performs the actual build from source. The script then copies the built `.deb` artifact out onto your local system ready for installation using `dpkg`.
 

--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,11 @@ IMAGE_TAG="$APP_NAME-build"
 #mkdir $BUILD_PATH
 #cd $BUILD_PATH
 
-docker build -t $IMAGE_TAG .
+BUILD_ARGS=""
+[[ -z ${1} ]] || BUILD_ARGS="--build-arg SNAPRAID_VERSION=$1"
+echo BUILD_ARGS=$BUILD_ARGS
+
+docker build -t $IMAGE_TAG $BUILD_ARGS .
 ID=$(docker create $IMAGE_TAG)
 docker cp $ID:/build/ .
 docker rm -v $ID


### PR DESCRIPTION
This would allow setting the version at build time

If having the version in an env var is still desired I could add

```dockerfile
ENV SNAPRAID_VERSION=$SNAPRAID_VERSION
```
