### PR TITLE
CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build deb
+        run: bash build.sh
+
+      - name: Store archives
+        uses: actions/upload-artifact@v2
+        with:
+          name: snapraid-deb.zip
+          path: build/*.deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,3 +20,4 @@ jobs:
         with:
           name: snapraid-deb.zip
           path: build/*.deb
+          if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ sudo dpkg -i snapraid*.deb
 
 The build script spins up a container, executes the `Dockerfile` which performs the actual build from source. The script then copies the built `.deb` artifact out onto your local system ready for installation using `dpkg`.
 
+To save building it yourself, you can also download the `.deb` file as an artifact from GitHub actions.
+
 If the version is out of date, please submit a Pull Request or open an issue.
 
 <May 2020> - This is still actively maintained but I don't seem to get notifications. I'm active on the [selfhosted.show](https://selfhosted.show/discord) discord or my email address is in the dockerfile. Give that a go if your PR sits stale for a while!

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # IronicBadger/docker-snapraid
 
+[![CI](https://github.com/IronicBadger/docker-snapraid/actions/workflows/ci.yml/badge.svg)](https://github.com/IronicBadger/docker-snapraid/actions/workflows/ci.yml)
+
 This container will allow you to build a Snapraid `.deb` file without installing any build dependencies on your system.
 
 ### Usage


### PR DESCRIPTION
Build the deb on CI, save compiling it yourself.

It still uses the container, so this also functions as a test for it.