### PR TITLE
Update to Snapraid 12.0 and Debian Bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM debian:buster
+FROM debian:bullseye
 MAINTAINER Alex Kretzschmar <alexktz@gmail.com>
 
 ARG SNAPRAID_VERSION="11.6"
 
 # Builds SnapRAID from source
-RUN echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list && \
+RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' > /etc/apt/sources.list.d/backports.list && \
       apt update && \
       apt install -y \
         gcc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:bullseye
 MAINTAINER Alex Kretzschmar <alexktz@gmail.com>
 
-ARG SNAPRAID_VERSION="11.6"
+ARG SNAPRAID_VERSION="12.0"
 
 # Builds SnapRAID from source
 RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' > /etc/apt/sources.list.d/backports.list && \


### PR DESCRIPTION
Hello there 👋️

I am a big fan of the self-hosted.show podcast and have been using a lot of the suggested tools to grow my homelab. One of these is snapraid, which is prominently featured in the perfectmediaserver wiki. This docker repo has been awesome for building the snapraid updates, since it saves me from cluttering my main server with build tools.

I figured I would try to give back a bit by updating the default version to Snapraid 12.0 (latest as of Dec 8th 2021). I also went ahead and updated the docker build to point to Debian Bullseye since that's the latest stable build of Debian.

I have already produced a snapraid.deb artifact on my homelab using this PR, and I've also run it against the provided CI configuration on my own repo, for whatever that may be worth:
https://github.com/Kmagameguy/docker-snapraid/runs/4576552252?check_suite_focus=true