### PR TITLE
Default to Latest SnapRAID Release & Use Debian Bullseye

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye
+FROM debian
 MAINTAINER Alex Kretzschmar <alexktz@gmail.com>
 
 ARG SNAPRAID_VERSION

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:buster
 MAINTAINER Alex Kretzschmar <alexktz@gmail.com>
 
-ARG SNAPRAID_VERSION="11.6"
+ARG SNAPRAID_VERSION
 
 # Builds SnapRAID from source
 RUN echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM debian:buster
+FROM debian:bullseye
 MAINTAINER Alex Kretzschmar <alexktz@gmail.com>
 
 ARG SNAPRAID_VERSION
 
 # Builds SnapRAID from source
-RUN echo 'deb http://deb.debian.org/debian buster-backports main' > /etc/apt/sources.list.d/backports.list && \
+RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' > /etc/apt/sources.list.d/backports.list && \
       apt update && \
       apt install -y \
         gcc \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,14 @@ MAINTAINER Alex Kretzschmar <alexktz@gmail.com>
 ARG SNAPRAID_VERSION
 
 # Builds SnapRAID from source
-RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' > /etc/apt/sources.list.d/backports.list && \
-      apt update && \
-      apt install -y \
-        gcc \
-        git \
-        make \
-        checkinstall \
-        curl \
-        libblkid1
+RUN apt update && \
+    apt install -y \
+      gcc \
+      git \
+      make \
+      checkinstall \
+      curl \
+      libblkid1
 RUN curl -LO https://github.com/amadvance/snapraid/releases/download/v${SNAPRAID_VERSION}/snapraid-${SNAPRAID_VERSION}.tar.gz && \
       tar -xvf snapraid-${SNAPRAID_VERSION}.tar.gz && \
       cd snapraid-${SNAPRAID_VERSION} && \

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 This container will allow you to build a Snapraid `.deb` file without installing any build dependencies on your system.
 
+### Pre-Requisites
+You will need a working copy of [docker][docker] to build the container.
+
 ### Usage
 
 ```sh
@@ -11,12 +14,12 @@ This container will allow you to build a Snapraid `.deb` file without installing
 sudo dpkg -i snapraid*.deb
 ```
 
-If the version is omitted, the default version is used.
+If the version is omitted, the latest version of SnapRAID is used.
 
 The build script spins up a container, executes the `Dockerfile` which performs the actual build from source. The script then copies the built `.deb` artifact out onto your local system ready for installation using `dpkg`.
 
 To save building it yourself, you can also download the `.deb` file as an artifact from GitHub actions.
 
-If the version is out of date, please submit a Pull Request or open an issue.
-
 <May 2020> - This is still actively maintained but I don't seem to get notifications. I'm active on the [selfhosted.show](https://selfhosted.show/discord) discord or my email address is in the dockerfile. Give that a go if your PR sits stale for a while!
+
+[docker]:https://docs.docker.com/engine/install/

--- a/build.sh
+++ b/build.sh
@@ -1,15 +1,29 @@
 #!/bin/bash
+
+set -Eeuo pipefail
+trap on_error ERR
+
+on_error() {
+  echo "Error on line $(caller): ${BASH_COMMAND}"
+}
+
+get_latest_snapraid_release() {
+  curl --silent "https://api.github.com/repos/amadvance/snapraid/releases/latest" | \
+    grep '"tag_name":' | \
+    sed -E 's/.*v([^"]+)".*/\1/'
+}
+
 APP_NAME="snapraid"
 IMAGE_TAG="$APP_NAME-build"
+LATEST_RELEASE_TAG="$(get_latest_snapraid_release)"
+BUILD_ARGS="--build-arg SNAPRAID_VERSION=${1:-$LATEST_RELEASE_TAG}"
 
 # Uncomment BUILD_PATH if using this Dockerfile as part of an Ansible deployment
 #BUILD_PATH="/tmp/build"
 #mkdir $BUILD_PATH
 #cd $BUILD_PATH
 
-BUILD_ARGS=""
-[[ -z ${1} ]] || BUILD_ARGS="--build-arg SNAPRAID_VERSION=$1"
-echo BUILD_ARGS=$BUILD_ARGS
+echo "BUILD_ARGS=$BUILD_ARGS"
 
 docker build -t $IMAGE_TAG $BUILD_ARGS .
 ID=$(docker create $IMAGE_TAG)

--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,8 @@ on_error() {
 }
 
 get_latest_snapraid_release() {
+  # grep gets the tag_name node from the API JSON
+  # sed regex extracts the version number, e.g. "12.0"
   curl --silent "https://api.github.com/repos/amadvance/snapraid/releases/latest" | \
     grep '"tag_name":' | \
     sed -E 's/.*v([^"]+)".*/\1/'


### PR DESCRIPTION
Hello there 👋️

I am a big fan of the self-hosted.show podcast and have been using a lot of the suggested tools & guidance to grow my homelab (I'm KmaGameGoof on the Discord).  This docker repo has been awesome for building SnapRAID updates since it saves me from cluttering my main server with build tools.

### What's Changed
I figured I would try to give back a bit by proposing this PR.  It does the following:
1. Queries the Github API for the latest SnapRAID release tag for use in the build.  As of time of writing, this is `12.0`.
    - The Github API allows [60 unauthenticated requests per hour](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting), which I think is suitable for consumers of this repo.
    - As  a fallback, the changes preserve the ability to call the script with an explicit release tag, e.g. `11.2`.
2. Pushes the Dockerfile up to Debian Bullseye, since that's the latest `stable` release of Debian
3. Updates a few minor details in the README

### Reasoning for Proposed Changes
Admittedly, all of this could be considered unnecessary, since you can pass a release version to the build script.  My interest in proposing these changes are as follows:
1. For someone utterly new to self-hosting, they won't have to research the SnapRAID repo to check for the latest release
2. It could be used in a cronjob to set & forget SnapRAID updates (I plan to do precisely this)
3. I believe I saw on the Discord that you might stop using SnapRAID in future media server builds; if that's the case, this PR makes it so you don't really have to maintain the repo anymore. I know SnapRAID isn't updated often but hopefully it means you won't have to attend to PRs/Twitter DMs/Discord questions about new releases, since the default install will always pull the latest

### Other Notes
I have already produced a `snapraid.deb` artifact on my homelab using this PR, and I've also run it against the provided CI configuration on my own repo, for whatever that may be worth (hopefully this link isn't set to private):
https://github.com/Kmagameguy/docker-snapraid/actions/runs/1599930507

Lastly, thank you for sharing your knowledge & experiences with the 'net!
