### PR TITLE
Get Builds Working Again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,14 @@ RUN apt update && \
       checkinstall \
       curl \
       libblkid1
+
+WORKDIR /src
 RUN curl -LO https://github.com/amadvance/snapraid/releases/download/v${SNAPRAID_VERSION}/snapraid-${SNAPRAID_VERSION}.tar.gz && \
-      tar -xvf snapraid-${SNAPRAID_VERSION}.tar.gz && \
-      cd snapraid-${SNAPRAID_VERSION} && \
-      ./configure && \
-      make -j4 && \
-      make -j4 check && \
-      checkinstall -Dy --install=no --nodoc && \
-      mkdir /build && \
-      cp *.deb /build/snapraid-from-source.deb
+      tar -xvf snapraid-${SNAPRAID_VERSION}.tar.gz
+WORKDIR /src/snapraid-${SNAPRAID_VERSION}
+RUN ./configure
+RUN make -j4
+RUN make -j4 check
+RUN checkinstall -Dy --install=no --nodoc
+RUN mkdir /build && \
+      cp *.deb /build/snapraid-${SNAPRAID_VERSION}.deb

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 set -Eeuo pipefail
@@ -16,16 +15,16 @@ get_latest_snapraid_release() {
     sed -E 's/.*v([^"]+)".*/\1/'
 }
 
-APP_NAME="snapraid"
-IMAGE_TAG="$APP_NAME-build"
+DOCKER_IMAGE_TAG="snapraid-build"
 LATEST_RELEASE_TAG="$(get_latest_snapraid_release)"
-BUILD_ARGS="--build-arg SNAPRAID_VERSION=${1:-$LATEST_RELEASE_TAG}"
 
 # Uncomment BUILD_PATH if using this Dockerfile as part of an Ansible deployment
 #BUILD_PATH="/tmp/build"
 #mkdir $BUILD_PATH
 #cd $BUILD_PATH
 
-echo "BUILD_ARGS=$BUILD_ARGS"
-
-docker build -o type=local,dest=./build/ $BUILD_ARGS .
+docker build -t "$DOCKER_IMAGE_TAG" --build-arg SNAPRAID_VERSION="${1:-$LATEST_RELEASE_TAG}" .
+IMAGE_ID="$(docker create $DOCKER_IMAGE_TAG)"
+docker cp "$IMAGE_ID:/build/" .
+docker rm -v "$IMAGE_ID"
+docker rmi "$DOCKER_IMAGE_TAG"


### PR DESCRIPTION
👋🏼 Hi there,

@ironicbadger, I'm not sure what happened after pull #18 but it seems like that one caused some issues.  I saw some folks having issues with this repo in the discord which prompted me to take a quick peek. When running the `master` branch code locally it doesn't seem to copy the build artifact from the container to the host.  It seems to me that's the reason CI is failing.

I'm no docker expert so this PR is a bit of a compromise - it keeps (most of) the Dockerfile changes so we get the caching benefits gravufo was after.  BUT, I've reverted to using the old method of spinning up a container using the finished image and running docker copy on it to extract the snapraid .deb.

This should fix CI and fixes #20 (and maybe #21, though I'm also testing on 22.04 and not seeing a problem with the -o option).  You can see the passing build in my fork:
https://github.com/Kmagameguy/docker-snapraid